### PR TITLE
Add MongoDB CRUD endpoints with FastAPI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
+
+.env
 venv/
+.env

--- a/FastAPI_Mongo.py
+++ b/FastAPI_Mongo.py
@@ -1,0 +1,90 @@
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel, Field
+from pymongo import MongoClient
+from typing import List
+
+# Connect to MongoDB
+client = MongoClient("mongodb://localhost:27017")
+db = client.user_db
+collection = db.users
+
+app = FastAPI()
+
+# Pydantic model (custom integer ID instead of ObjectId)
+class User(BaseModel):
+    id: int
+    name: str = Field(default="Farida")
+    age: int = Field(default=23)
+
+# Helper function
+def user_helper(user) -> dict:
+    return {
+        "id": user["_id"],  # your custom int id will be used as _id
+        "name": user["name"],
+        "age": user["age"]
+    }
+
+from pymongo import MongoClient
+from bson import ObjectId
+
+client = MongoClient("mongodb://localhost:27017")
+db = client.user_db
+collection = db.users
+
+# Delete all documents where _id is of type ObjectId
+collection.delete_many({"_id": {"$type": "objectId"}})
+
+
+# POST - Create User
+@app.post("/Create", response_model=User)
+def create_user(user: User):
+    if collection.find_one({"_id": user.id}):
+        raise HTTPException(status_code=400, detail="User with this ID already exists")
+    collection.insert_one({
+        "_id": user.id,
+        "name": user.name,
+        "age": user.age
+    })
+    return user
+
+# GET - All users
+@app.get("/Get_Users", response_model=List[User])
+def get_users():
+    users = []
+    for user in collection.find():
+        try:
+            users.append(user_helper(user))
+        except Exception:
+            continue  # skip malformed records
+    return users
+
+
+# GET - One user by custom ID
+@app.get("/Get_User/{user_id}", response_model=User)
+def get_user(user_id: int):
+    user = collection.find_one({"_id": user_id})
+    if not user:
+        raise HTTPException(status_code=404, detail="User not found")
+    return user_helper(user)
+
+# PUT - Update user
+@app.put("/Update/{user_id}", response_model=User)
+def update_user(user_id: int, updated_user: User):
+    result = collection.update_one(
+        {"_id": user_id},
+        {"$set": {
+            "name": updated_user.name,
+            "age": updated_user.age
+        }}
+    )
+    if result.matched_count == 0:
+        raise HTTPException(status_code=404, detail="User not found")
+    return updated_user
+
+# DELETE - Delete user
+@app.delete("/Delete/{user_id}")
+def delete_user(user_id: int):
+    result = collection.delete_one({"_id": user_id})
+    if result.deleted_count == 0:
+        raise HTTPException(status_code=404, detail="User not found")
+    return {"message": "User deleted"}

--- a/FastAPI_Mongo.py
+++ b/FastAPI_Mongo.py
@@ -2,9 +2,18 @@ from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field
 from pymongo import MongoClient
 from typing import List
+from dotenv import load_dotenv
+import os
+
+load_dotenv()  
+
+MONGO_URI = os.getenv("MONGO_URI")
+
+if not MONGO_URI:
+    raise ValueError("MONGO_URI environment variable not set")
 
 # Connect to MongoDB
-client = MongoClient("mongodb://localhost:27017")
+client = MongoClient(MONGO_URI)
 db = client.user_db
 collection = db.users
 
@@ -27,7 +36,7 @@ def user_helper(user) -> dict:
 from pymongo import MongoClient
 from bson import ObjectId
 
-client = MongoClient("mongodb://localhost:27017")
+client = MongoClient(MONGO_URI)
 db = client.user_db
 collection = db.users
 


### PR DESCRIPTION
## Summary

This PR adds a new FastAPI endpoint to manage user data using a MongoDB backend.

## Changes Made
- Connected FastAPI to MongoDB using PyMongo
- Created CRUD routes: Create, Read (all and one), Update, Delete
- Used `.env` file to hide MongoDB URI
- Used Pydantic for request/response validation
- Ensured only custom `int` IDs are used (not ObjectId)

## How to Test
1. Run the app: `uvicorn FastAPI_Mongo:app --reload`
2. Use Swagger UI at `http://127.0.0.1:8000/docs`
3. Test POST, GET, PUT, and DELETE endpoints

## Notes
- `.env` file is excluded via `.gitignore`
- All users stored with `id`, `name`, and `age` fields
